### PR TITLE
chore: bump actions/checkout from 4.1.7 to 4.2.2

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       -
         name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
       -
         name: Get go.mod details
         uses: Eun/go-mod-details@v1.0.7
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
       -
         uses: actions/setup-go@v5
       # we cannot use nancy-github-action because it is outdated, so it's better to use the latest
@@ -53,7 +53,7 @@ jobs:
     steps:
       -
         name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
       -
         name: Get go.mod details
         uses: Eun/go-mod-details@v1.0.7


### PR DESCRIPTION
## Description


update bump actions/checkout from 4.1.7 to 4.2.2

