### PR TITLE
chore: bump golangci/golangci-lint-action from 6.1.0 to 6.1.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: ${{ steps.go-mod-details.outputs.go_version }}
       -
         name: Lint
-        uses: golangci/golangci-lint-action@v6.1.0
+        uses: golangci/golangci-lint-action@v6.1.1
         with:
           version: v1.55.2
           # optional: show only new issues if it's a pull request. The default value is `false`.


### PR DESCRIPTION
## Description

update golangci/golangci-lint-action from 6.1.0 to 6.1.1